### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Data/String/HtmlElement.js
+++ b/src/Data/String/HtmlElement.js
@@ -1,12 +1,12 @@
 var he = require('he');
 
-exports["encode'"] = function (options) {
+exports.encodeWith = function (options) {
   return function (string) {
     return he.encode(string, options);
   };
 };
 
-exports["decode'"] = function (options) {
+exports.decodeWith = function (options) {
   return function(string) {
     return he.decode(string, options);
   };

--- a/src/Data/String/HtmlElement.purs
+++ b/src/Data/String/HtmlElement.purs
@@ -9,8 +9,15 @@ module Data.String.HtmlElements
   , defaultDecodeOptions
   ) where
 
-foreign import encode' :: EncodeOptions -> String -> String
-foreign import decode' :: DecodeOptions -> String -> String
+foreign import encodeWith :: EncodeOptions -> String -> String
+
+encode' :: EncodeOptions -> String -> String
+encode' = encodeWith
+
+foreign import decodeWith :: DecodeOptions -> String -> String
+
+decode' :: DecodeOptions -> String -> String
+decode' = decodeWith
 
 type EncodeOptions =
   { useNamedReferences :: Boolean


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.