### PR TITLE
Upgrade `purescript-test-unit` to v16.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "purescript-test-unit": "^15.0.0"
+    "purescript-test-unit": "^16.0.0"
   }
 }


### PR DESCRIPTION
This PR upgrades the `purescript-test-unit` dependency to the latest version available in the package set to ensure continued compatibility.

### Motivation

`node-he` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have these dependency issues resolved in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.